### PR TITLE
Create directories for client secret path before saving

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -65,7 +65,13 @@ func NewApp(client *googs.Client) *App {
 
 	// Precreated pages which are not required to follow Page interface
 	app.root.AddPage("login", newLoginPage(app, func() {
-		if err := app.client.Save(config.SecretPath(app.client.Username)); err != nil {
+		
+		path := config.SecretPath(app.client.Username)
+		// Create directories to path or the initial save will fail on linux
+		if err := os.MkdirAll(filepath.Dir(path), 0770); err != nil {
+			panic(err)
+		}
+		if err := app.client.Save(path); err != nil {
 			panic(err)
 		}
 		app.onLoggedIn()


### PR DESCRIPTION
On linux when you first start up the application it crashes after the login page because it cannot create the full directory path for saving the client secret path. This change ensures that all the directories are created before you save. 

I wasn't sure to contribute this change to here or the googs repo, but I thought this definitely needs the change to not crash